### PR TITLE
Update xteve.me

### DIFF
--- a/addons/.help/xteve.me
+++ b/addons/.help/xteve.me
@@ -2,7 +2,9 @@ xteve is a M3U Proxy for Plex DVR and Emby Live TV
 use ( http://xteve:34400 ) for in-app communication
 
 Install Notes:
-UI will be accessible on xteve.domain.com/web - Accessing xteve.domain.com will throw an XML error in the current version.
+UI will be accessible on xteve.domain.com/web
+       Accessing xteve.domain.com 
+will throw an XML error in the current version.
 
 Settings to edit in xteve: 
 -Playlist (add yours)
@@ -11,7 +13,12 @@ Settings to edit in xteve:
 
 When setting it up in plex: 
 -Add xteve:34400 as tuner
--If you want to use the EPG from XTEVE (XEPG) the link you set in Plex must be 
+-If you want to use the EPG from XTEVE (XEPG)
+the link you set in Plex must be
+
 http://xteve:34400/xmltv/xteve.xml
 
-Protip: Manage,modulate and shorten your m3u link on www.m3u4u.com - They also have an excellent EPG & Playlist editor
+Protip:
+Manage,modulate and shorten your
+        m3u linkon www.m3u4u.com -
+They also have an excellent EPG & Playlist editor

--- a/addons/.help/xteve.me
+++ b/addons/.help/xteve.me
@@ -1,2 +1,17 @@
 xteve is a M3U Proxy for Plex DVR and Emby Live TV
 use ( http://xteve:34400 ) for in-app communication
+
+Install Notes:
+UI will be accessible on xteve.domain.com/web - Accessing xteve.domain.com will throw an XML error in the current version.
+
+Settings to edit in xteve: 
+-Playlist (add yours)
+-EPG source (unless you use the one in Plex)
+-Settings -> Buffer -> Xteve -> Buffer size 8MB
+
+When setting it up in plex: 
+-Add xteve:34400 as tuner
+-If you want to use the EPG from XTEVE (XEPG) the link you set in Plex must be 
+http://xteve:34400/xmltv/xteve.xml
+
+Protip: Manage,modulate and shorten your m3u link on www.m3u4u.com - They also have an excellent EPG & Playlist editor


### PR DESCRIPTION
xteve is a M3U Proxy for Plex DVR and Emby Live TV
use ( http://xteve:34400 ) for in-app communication

Install Notes:
Access interface will be  accessible on xteve.domain.com/web - Accessing xteve.domain.com will throw an XML error in the current version.

Settings to edit in xteve: 
-Playlist (add yours)
-EPG source (unless you use the one in Plex)
-Settings -> Buffer -> Xteve -> Buffer size 8MB

When setting it up in plex: 
-Add xteve:34400 as tuner
-If you want to use the EPG from XTEVE (XEPG) the link you set in Plex must be 
http://xteve:34400/xmltv/xteve.xml

Protip: Manage,modulate and shorten your m3u link on www.m3u4u.com - They also have an excellent EPG & Playlist editor